### PR TITLE
Fix READMEs fetched from GitHub

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -15,6 +15,12 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.2",
-    "daisyui": "^2.15.0"
+    "daisyui": "^2.15.0",
+    "remark": "^14.0.2",
+    "remark-frontmatter": "^4.0.1",
+    "remark-gemoji": "^7.0.1",
+    "remark-gfm": "^3.0.1",
+    "unist-util-remove": "^3.1.0",
+    "unist-util-visit": "^4.1.0"
   }
 }

--- a/www/src/pages/[category]/[project].astro
+++ b/www/src/pages/[category]/[project].astro
@@ -3,7 +3,6 @@ import NotionData from '../../data/notion.json'
 import { Markdown } from 'astro/components';
 import Base from '../../layouts/Base.astro';
 import formatCategoryString from '../../scripts/formatCategoryString';
-import getGitUserName from '../../scripts/getGitUserName';
 import fetchREADMEfromGithub from '../../scripts/fetchREADMEfromGithub';
 
 export async function getStaticPaths() {
@@ -22,8 +21,7 @@ export async function getStaticPaths() {
  }
 const {category,project}=Astro.params
 const {record}=Astro.props
-const gitUser = getGitUserName(record.GitHub)
-const readme = await fetchREADMEfromGithub(gitUser,record.Name.toLowerCase())
+const readme = await fetchREADMEfromGithub(record.GitHub)
 
 ---
 <Base>

--- a/www/src/scripts/fetchREADMEfromGithub.ts
+++ b/www/src/scripts/fetchREADMEfromGithub.ts
@@ -114,9 +114,6 @@ function absoluteLinks({ base }: { base: string }) {
       /(?<=href=")(?!https?:\/\/)\/?(.+)(?=")/g,
       `${base}$1`
     );
-    if (node.value.includes('href')) {
-      console.log(node.value);
-    }
   }
 
   function transform(tree: Root) {

--- a/www/src/scripts/fetchREADMEfromGithub.ts
+++ b/www/src/scripts/fetchREADMEfromGithub.ts
@@ -30,8 +30,11 @@ export default async function fetchREADMEfromGithub(
   // Remove trailing slash
   if (repoURL.at(-1) === '/') repoURL = repoURL.slice(0, -1);
 
-  const [user, repo] = repoURL.split('/').slice(-2);
-  const url = `https://api.github.com/repos/${user}/${repo}/readme`;
+  const [, user, repo, rest] = repoURL.match(
+    /^https?:\/\/github.com\/([^/]+)\/([^/]+)(.*)/
+  );
+  const dir = rest ? '/' + rest.split('/').slice(3).join('/') : '';
+  const url = `https://api.github.com/repos/${user}/${repo}/readme${dir}`;
 
   const response = await fetch(url, {
     headers: {
@@ -43,7 +46,11 @@ export default async function fetchREADMEfromGithub(
   });
 
   if (response.status >= 400) {
-    console.error(response);
+    console.error(
+      `Failed to fetch README for ${user}/${repo}\nError:`,
+      response.status,
+      response.statusText
+    );
     return 'No README found!';
   }
 

--- a/www/src/scripts/fetchREADMEfromGithub.ts
+++ b/www/src/scripts/fetchREADMEfromGithub.ts
@@ -1,3 +1,109 @@
-export default async function fetchREADMEfromGithub(user:string,project:string):Promise<string>{
-    return  await (await fetch(`https://raw.githubusercontent.com/${user}/${project}/main/README.md`)).text()
+import type { Root } from 'mdast';
+import { remark } from 'remark';
+import parseFrontmatter from 'remark-frontmatter';
+import emoji from 'remark-gemoji';
+import gfm from 'remark-gfm';
+import { remove } from 'unist-util-remove';
+import { visit } from 'unist-util-visit';
+
+const token: string | undefined = import.meta.env.PUBLIC_GITHUB_TOKEN;
+
+if (!token) {
+  console.error(
+    'Cannot find environment variable "PUBLIC_GITHUB_TOKEN" used for escaping GitHub API rate-limiting.'
+  );
+}
+
+/**
+ * Fetch the README for a GitHub repo based on its URL.
+ *
+ * Fetches using the GitHub API and applies some custom remark transforms
+ * to better handle content written for GitHub:
+ * - Deletes any frontmatter
+ * - Applies “GitHub-flavoured Markdown” (includes stuff like strikethrough with `~~`)
+ * - Enables “Gemoji” (`:rocket:` => 🚀)
+ * - Prepends relative links & image sources with the correct absolute base
+ */
+export default async function fetchREADMEfromGithub(
+  repoURL: string
+): Promise<string> {
+  // Remove trailing slash
+  if (repoURL.at(-1) === '/') repoURL = repoURL.slice(0, -1);
+
+  const [user, repo] = repoURL.split('/').slice(-2);
+  const url = `https://api.github.com/repos/${user}/${repo}/readme`;
+
+  const response = await fetch(url, {
+    headers: {
+      accept: 'application/vnd.github.v3.json',
+      Authorization:
+        token && `Basic ${Buffer.from(token, 'binary').toString('base64')}`,
+      'User-Agent': 'Astro-Hackathon-Showcase',
+    },
+  });
+
+  if (response.status >= 400) {
+    console.error(response);
+    return 'No README found!';
+  }
+
+  const { content, download_url, html_url } = await response.json();
+
+  const processor = remark()
+    .use(parseFrontmatter)
+    .use(stripFrontmatter)
+    .use(gfm)
+    .use(emoji)
+    .use(absoluteImageURLs, { base: stripFilename(download_url) })
+    .use(absoluteLinks, { base: stripFilename(html_url) });
+
+  // Parse the Markdown returned by the API which is encoded in base-64
+  const md = Buffer.from(content, 'base64').toString('utf-8');
+
+  // Run the Markdown through the remark processing pipeline
+  const processedMd = (await processor.process(md)).toString();
+
+  return processedMd;
+}
+
+/** Remove the last segment of a URL, kind of like `dirname`. */
+function stripFilename(url: string) {
+  return url.split('/').slice(0, -1).join('/') + '/';
+}
+
+/** Remark plugin to prepend an absolute path in front of image src URLs. */
+function absoluteImageURLs({ base }: { base: string }) {
+  function visitor(node) {
+    // Sanitize URL by removing leading `/`
+    const relativeUrl = node.url.replace(/^.?\//, '');
+    node.url = new URL(relativeUrl, base).href;
+  }
+
+  function transform(tree: Root) {
+    visit(tree, 'image', visitor);
+  }
+
+  return transform;
+}
+
+/** Remark plugin to prepend an absolute path in front of link hrefs. */
+function absoluteLinks({ base }: { base: string }) {
+  function visitor(node) {
+    // Sanitize URL by removing leading `/`
+    const relativeUrl = node.url.replace(/^.?\//, '');
+    node.url = new URL(relativeUrl, base).href;
+  }
+
+  function transform(tree: Root) {
+    visit(tree, 'link', visitor);
+  }
+
+  return transform;
+}
+
+/** Remark plugin to strip frontmatter parsed with `remark-frontmatter`. */
+function stripFrontmatter() {
+  return function transform(tree: Root) {
+    remove(tree, 'yaml');
+  };
 }

--- a/www/src/scripts/fetchREADMEfromGithub.ts
+++ b/www/src/scripts/fetchREADMEfromGithub.ts
@@ -86,8 +86,16 @@ function absoluteImageURLs({ base }: { base: string }) {
     node.url = new URL(relativeUrl, base).href;
   }
 
+  function htmlVisitor(node) {
+    node.value = node.value.replaceAll(
+      /(?<=src=")(?!https?:\/\/)\/?(.+)(?=")/g,
+      `${base}$1`
+    );
+  }
+
   function transform(tree: Root) {
     visit(tree, 'image', visitor);
+    visit(tree, 'html', htmlVisitor);
   }
 
   return transform;
@@ -101,8 +109,19 @@ function absoluteLinks({ base }: { base: string }) {
     node.url = new URL(relativeUrl, base).href;
   }
 
+  function htmlVisitor(node) {
+    node.value = node.value.replaceAll(
+      /(?<=href=")(?!https?:\/\/)\/?(.+)(?=")/g,
+      `${base}$1`
+    );
+    if (node.value.includes('href')) {
+      console.log(node.value);
+    }
+  }
+
   function transform(tree: Root) {
     visit(tree, 'link', visitor);
+    visit(tree, 'html', htmlVisitor);
   }
 
   return transform;

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -1352,6 +1352,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fault@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-2.0.1.tgz#d47ca9f37ca26e4bd38374a7c500b5a384755b6c"
+  integrity sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==
+  dependencies:
+    format "^0.2.0"
+
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.5.tgz#0077bf5f3fcdbd9d75a0b5362f77dbb743489863"
@@ -1398,6 +1405,11 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
 formdata-polyfill@^4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
@@ -1434,6 +1446,11 @@ functions-have-names@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+gemoji@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/gemoji/-/gemoji-7.1.0.tgz#165403777681a9690d649aabd104da037bdd7739"
+  integrity sha512-wI0YWDIfQraQMDs0yXAVQiVBZeMm/rIYssf8LZlMDdssKF19YqJKOHkv4zvwtVQTBJ0LNmErv1S+DqlVUudz8g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2103,6 +2120,13 @@ mdast-util-from-markdown@^1.0.0:
     unist-util-stringify-position "^3.0.0"
     uvu "^0.5.0"
 
+mdast-util-frontmatter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.0.tgz#ef12469379782e4a0fd995fed60cc3b871e6c819"
+  integrity sha512-7itKvp0arEVNpCktOET/eLFAYaZ+0cNjVtFtIPxgQ5tV+3i+D4SDDTjTzPWl44LT59PC+xdx+glNTawBdF98Mw==
+  dependencies:
+    micromark-extension-frontmatter "^1.0.0"
+
 mdast-util-gfm-autolink-literal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.2.tgz#4032dcbaddaef7d4f2f3768ed830475bb22d3970"
@@ -2255,6 +2279,15 @@ micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
     micromark-util-symbol "^1.0.0"
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
+
+micromark-extension-frontmatter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.0.0.tgz#612498e6dad87c132c95e25f0918e7cc0cd535f6"
+  integrity sha512-EXjmRnupoX6yYuUJSQhrQ9ggK0iQtQlpi6xeJzVD5xscyAI+giqco5fdymayZhJMbIFecjnE2yz85S9NzIgQpg==
+  dependencies:
+    fault "^2.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
 
 micromark-extension-gfm-autolink-literal@^1.0.0:
   version "1.0.3"
@@ -2985,6 +3018,26 @@ rehype-stringify@^9.0.3:
     hast-util-to-html "^8.0.0"
     unified "^10.0.0"
 
+remark-frontmatter@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz#84560f7ccef114ef076d3d3735be6d69f8922309"
+  integrity sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-frontmatter "^1.0.0"
+    micromark-extension-frontmatter "^1.0.0"
+    unified "^10.0.0"
+
+remark-gemoji@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/remark-gemoji/-/remark-gemoji-7.0.1.tgz#42488adb9a0731dc82cdcde45f8e7bd61d795303"
+  integrity sha512-vhjuntkvYxRgM4Um6L5N7B3SrNu3eX6jNqpqAywpAvSYPbmDPNL3I5E6zWm+KPCyh3OpKRc5OPnz7SifggzePw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    gemoji "^7.0.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+
 remark-gfm@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"
@@ -2995,7 +3048,7 @@ remark-gfm@^3.0.1:
     micromark-extension-gfm "^2.0.0"
     unified "^10.0.0"
 
-remark-parse@^10.0.1:
+remark-parse@^10.0.0, remark-parse@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
   integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
@@ -3022,6 +3075,25 @@ remark-smartypants@^2.0.0:
     retext "^8.1.0"
     retext-smartypants "^5.1.0"
     unist-util-visit "^4.1.0"
+
+remark-stringify@^10.0.0:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-10.0.2.tgz#50414a6983f5008eb9e72eed05f980582d1f69d7"
+  integrity sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-markdown "^1.0.0"
+    unified "^10.0.0"
+
+remark@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-14.0.2.tgz#4a1833f7441a5c29e44b37bb1843fb820797b40f"
+  integrity sha512-A3ARm2V4BgiRXaUo5K0dRvJ1lbogrbXnhkJRmD0yw092/Yl0kOCZt1k9ZeElEwkZsWGsMumz6qL5MfNJH9nOBA==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    remark-parse "^10.0.0"
+    remark-stringify "^10.0.0"
+    unified "^10.0.0"
 
 resolve@^1.17.0, resolve@^1.22.0:
   version "1.22.0"
@@ -3537,6 +3609,15 @@ unist-util-remove-position@^4.0.0:
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-visit "^4.0.0"
+
+unist-util-remove@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-3.1.0.tgz#8042577e151dac989b7517976bfe4bac58f76ccd"
+  integrity sha512-rO/sIghl13eN8irs5OBN2a4RC10MsJdiePCfwrvnzGtgIbHcDXr2REr0qi9F2r/CIb1r9FyyFmcMRIGs+EyUFw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.0.0"
 
 unist-util-stringify-position@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
The previous technique for fetching GitHub READMEs was a bit broken because it relied on the repo’s default branch being `main`, which turned out not to always be the case.

This PR uses the GitHub REST API to fetch the READMEs instead. This requires a GitHub Access Token to be added to the build environment variables as `PUBLIC_GITHUB_TOKEN`, but is a much more reliable way to get the content.

Once I’d done that, I realised a bunch more rendering limitations with just plonking the raw Markdown from GitHub on a page: broken images & links and rendering anomalies. So I’ve built a remark pipeline to try to quickly emulate GitHub’s rendering and fix the images and links. It’s a bit like npm’s `marky-markdown`, but that doesn’t seem to be compatible with modern projects.