### PR TITLE
Wrap READMEs in a stylish box

### DIFF
--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config';
 
-import tailwind from "@astrojs/tailwind";
+import tailwind from '@astrojs/tailwind';
 
 // https://astro.build/config
 export default defineConfig({
@@ -8,5 +8,5 @@ export default defineConfig({
     // Can be 'shiki' (default), 'prism' or false to disable highlighting
     syntaxHighlight: 'prism',
   },
-  integrations: [tailwind()]
+  integrations: [tailwind({ config: { applyBaseStyles: false } })],
 });

--- a/www/src/layouts/Base.astro
+++ b/www/src/layouts/Base.astro
@@ -1,4 +1,6 @@
 ---
+import '../styles/base.css';
+
 export interface Props {
   title?: string;
 }

--- a/www/src/pages/[category]/[project].astro
+++ b/www/src/pages/[category]/[project].astro
@@ -27,7 +27,23 @@ const readme = await fetchREADMEfromGithub(gitUser,record.Name.toLowerCase())
 
 ---
 <Base>
-    <div class="prose container mx-auto px-3">
-        <Markdown content={readme}/>
+<div class="container mx-auto px-3">
+    <div class="mockup-window prose mx-auto border border-primary bg-primary text-primary-content">
+        <div class="p-4 bg-base-100 text-base-content">
+            <Markdown content={readme} />
+        </div>
     </div>
+</div>
 </Base>
+
+<style>
+.mockup-window::after {
+  content: "README.md";
+  position: absolute;
+  top: 0.85rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-weight: bold;
+  font-size: 0.85rem;
+}
+</style>

--- a/www/src/pages/[category]/[project].astro
+++ b/www/src/pages/[category]/[project].astro
@@ -28,22 +28,13 @@ const readme = await fetchREADMEfromGithub(gitUser,record.Name.toLowerCase())
 ---
 <Base>
 <div class="container mx-auto px-3">
-    <div class="mockup-window prose mx-auto border border-primary bg-primary text-primary-content">
+    <div class="mockup-window prose mx-auto border border-primary bg-primary">
         <div class="p-4 bg-base-100 text-base-content">
+            <a class="absolute w-full -top-2 left-1/2 -translate-x-1/2 font-bold no-underline text-center" href={record.GitHub + '#readme'}>
+                <h3 class="text-sm text-primary-content">README.md</h3>
+            </a>
             <Markdown content={readme} />
         </div>
     </div>
 </div>
 </Base>
-
-<style>
-.mockup-window::after {
-  content: "README.md";
-  position: absolute;
-  top: 0.85rem;
-  left: 50%;
-  transform: translateX(-50%);
-  font-weight: bold;
-  font-size: 0.85rem;
-}
-</style>

--- a/www/src/styles/base.css
+++ b/www/src/styles/base.css
@@ -1,0 +1,20 @@
+/* The integration's default injected base.css file */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: unset;
+}
+
+.prose :where(img):not(:where([class~='not-prose'] *)) {
+  margin-top: unset;
+  margin-bottom: unset;
+}


### PR DESCRIPTION
This PR adds some layout styles to the READMEs on each project’s page:

| dark | light |
|---|---|
| ![Screen Shot 2022-05-22 at 01 15 43](https://user-images.githubusercontent.com/357379/169671889-3bd3687e-3632-4862-b50a-1f368fd50aee.png) | ![Screen Shot 2022-05-22 at 01 16 05-fullpage](https://user-images.githubusercontent.com/357379/169671896-9f60a458-58da-4356-9b88-7f30c29aa84e.png) |

