### PR TITLE
Use grid instead of columns to lay out showcase cards

### DIFF
--- a/www/src/components/Card.astro
+++ b/www/src/components/Card.astro
@@ -6,7 +6,7 @@ import formatCategoryString from "../scripts/formatCategoryString";
     const gitUser = data.GitHub.split('/')[3]
 
 ---
-<a class="card break-inside-avoid p-4 bg-base-100 shadow-xl grid grid-cols-4 grid-rows-2 text-center" href={`${formatCategoryString(data.Category)}/${data.Name.toLowerCase()}`}>
+<a class="card p-4 bg-base-100 shadow-xl grid grid-cols-4 grid-rows-2 text-center" href={`${formatCategoryString(data.Category)}/${data.Name.toLowerCase()}`}>
     <h3 class="project-title text-lg font-bold col-start-2 col-span-3 self-end border-b border-primary px-3 pb-1 whitespace-nowrap text-ellipsis overflow-hidden">{capitalizeWords(data.Name.replaceAll('-',' '))}</h3>
     <div class="avatar row-span-full place-self-center">
         <div class="w-20 rounded-full">

--- a/www/src/components/Collection.astro
+++ b/www/src/components/Collection.astro
@@ -7,7 +7,7 @@ const { title } = Astro.props as Props;
 ---
 <div class="container mx-auto px-3 space-y-8">
   <h2 class="text-3xl">{title}</h2>
-  <div class="columns-2xs gap-6 space-y-3 sm:space-y-6">
+  <div class="grid gap-6 gap-y-3 sm:gap-y-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
     <slot/>
   </div>
 </div>


### PR DESCRIPTION
This PR fixes the issue with shadow getting clipped because of Chrome’s handling of CSS columns. It switches the layout to use CSS grid with media queries instead.